### PR TITLE
Use `--frozen`

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
+      - name: git status
+        run: git status
+
       - name: "${{ matrix.name }}"
         run: uv ${{ matrix.command }}
 

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -42,10 +42,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Install the project
-        run: uv sync --all-extras --dev
-
-      - name: git status
-        run: git status
+        run: uv sync --all-extras --dev --frozen
 
       - name: "${{ matrix.name }}"
         run: uv ${{ matrix.command }}


### PR DESCRIPTION
We failed to build `v0.0.1` because the working tree was dirty, and it was dirty because we didn't freeze the lock.