### PR TITLE
Fix lefthook + ruff

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,9 +3,15 @@ pre-commit:
   commands:
     ruff-format:
       glob: "*.py"
-      run: uv run ruff format {staged_files}
+      run: uv run ruff format --exit-non-zero-on-format {staged_files}
+      stage_fixed: true
+      tags:
+        - ruff
     ruff-fix:
       glob: "*.py"
-      run: uv run ruff check --fix {staged_files}
+      run: uv run ruff check --fix --exit-non-zero-on-fix {staged_files}
+      stage_fixed: true
+      tags:
+        - ruff
     pyright:
       run: uv run pyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,4 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
+ruff = { git = "https://github.com/thejcannon/ruff.git", rev = "exit-non-zero-on-format" }

--- a/src/shimbboleth/internal/clay/_validators.py
+++ b/src/shimbboleth/internal/clay/_validators.py
@@ -113,9 +113,9 @@ def get_union_type_validators(field_type: UnionType) -> Iterable[Validator]:
     }
 
     if is_shimbboleth_pytesting():
-        assert (
-            len(validators_by_type) == len(field_type.__args__)
-        ), f"Overlapping outer types in Union is unsupported: Input: `{field_type.__args__}`. Result: `{validators_by_type}`."
+        assert len(validators_by_type) == len(field_type.__args__), (
+            f"Overlapping outer types in Union is unsupported: Input: `{field_type.__args__}`. Result: `{validators_by_type}`."
+        )
 
     validators_by_type = {
         key: tuple(value) for key, value in validators_by_type.items() if value

--- a/src/shimbboleth/internal/clay/json_load.py
+++ b/src/shimbboleth/internal/clay/json_load.py
@@ -128,9 +128,9 @@ def load_union_type(field_type: UnionType, *, data: Any):
 
     if is_shimbboleth_pytesting():
         jsontypes = {_get_jsontype(argT) for argT in field_type.__args__}
-        assert (
-            len(field_type.__args__) == len(jsontypes)
-        ), f"Overlapping outer types in Union is unsupported: Input: `{field_type.__args__}`. Result: `{jsontypes}`."
+        assert len(field_type.__args__) == len(jsontypes), (
+            f"Overlapping outer types in Union is unsupported: Input: `{field_type.__args__}`. Result: `{jsontypes}`."
+        )
 
     for argT in field_type.__args__:
         expected_type = _get_jsontype(argT)

--- a/src/shimbboleth/internal/clay/json_schema.py
+++ b/src/shimbboleth/internal/clay/json_schema.py
@@ -212,9 +212,9 @@ class _ModelFieldSchemaHelper:
                 "json_schema_type", json_loader.__annotations__["value"]
             )
             output_type = json_loader.__annotations__["return"]
-            assert (
-                output_type == field.type
-            ), f"for {json_loader} {output_type=} {field.type=}"
+            assert output_type == field.type, (
+                f"for {json_loader} {output_type=} {field.type=}"
+            )
             return schema(input_type, model_defs=model_defs)
         return schema(field.type, model_defs=model_defs)
 

--- a/src/shimbboleth/internal/clay/model/_model.py
+++ b/src/shimbboleth/internal/clay/model/_model.py
@@ -2,7 +2,7 @@
 Module defining the `Model` base class for all shimbboleth modeling.
 """
 
-from typing import Any, Self, TypeVar, Callable
+from typing import Self, TypeVar, Callable
 from collections.abc import Mapping
 import dataclasses
 
@@ -26,9 +26,9 @@ class Model(_ModelBase, metaclass=ModelMeta):
         field = cls.__dataclass_fields__[field]
 
         assert isinstance(field, dataclasses.Field), "Did you forget to = field(...)?"
-        assert (
-            "json_loader" not in field.metadata
-        ), f"Only one loader per field. Already: {field.metadata['json_loader']}"
+        assert "json_loader" not in field.metadata, (
+            f"Only one loader per field. Already: {field.metadata['json_loader']}"
+        )
 
         def decorator(func: T) -> T:
             # NB: `metadata` is immutable, so copy/reassign
@@ -48,9 +48,9 @@ class Model(_ModelBase, metaclass=ModelMeta):
     @staticmethod
     def _json_dumper_(field) -> Callable[[T], T]:
         assert isinstance(field, dataclasses.Field), "Did you forget to = field(...)?"
-        assert (
-            "json_dumper" not in field.metadata
-        ), f"Only one dumper per field. Already: {field.metadata['json_dumper']}"
+        assert "json_dumper" not in field.metadata, (
+            f"Only one dumper per field. Already: {field.metadata['json_dumper']}"
+        )
 
         def decorator(func: T) -> T:
             # NB: `metadata` is immutable, so copy/reassign

--- a/uv.lock
+++ b/uv.lock
@@ -342,32 +342,12 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/06/09d1276df977eece383d0ed66052fc24ec4550a61f8fbc0a11200e690496/ruff-0.7.3.tar.gz", hash = "sha256:e1d1ba2e40b6e71a61b063354d04be669ab0d39c352461f3d789cac68b54a313", size = 3243664 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/56/933d433c2489e4642487b835f53dd9ff015fb3d8fa459b09bb2ce42d7c4b/ruff-0.7.3-py3-none-linux_armv6l.whl", hash = "sha256:34f2339dc22687ec7e7002792d1f50712bf84a13d5152e75712ac08be565d344", size = 10372090 },
-    { url = "https://files.pythonhosted.org/packages/20/ea/1f0a22a6bcdd3fc26c73f63a025d05bd565901b729d56bcb093c722a6c4c/ruff-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fb397332a1879b9764a3455a0bb1087bda876c2db8aca3a3cbb67b3dbce8cda0", size = 10190037 },
-    { url = "https://files.pythonhosted.org/packages/16/74/aca75666e0d481fe394e76a8647c44ea919087748024924baa1a17371e3e/ruff-0.7.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:37d0b619546103274e7f62643d14e1adcbccb242efda4e4bdb9544d7764782e9", size = 9811998 },
-    { url = "https://files.pythonhosted.org/packages/20/a1/cf446a0d7f78ea1f0bd2b9171c11dfe746585c0c4a734b25966121eb4f5d/ruff-0.7.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d59f0c3ee4d1a6787614e7135b72e21024875266101142a09a61439cb6e38a5", size = 10620626 },
-    { url = "https://files.pythonhosted.org/packages/cd/c1/82b27d09286ae855f5d03b1ad37cf243f21eb0081732d4d7b0d658d439cb/ruff-0.7.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:44eb93c2499a169d49fafd07bc62ac89b1bc800b197e50ff4633aed212569299", size = 10177598 },
-    { url = "https://files.pythonhosted.org/packages/b9/42/c0acac22753bf74013d035a5ef6c5c4c40ad4d6686bfb3fda7c6f37d9b37/ruff-0.7.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6d0242ce53f3a576c35ee32d907475a8d569944c0407f91d207c8af5be5dae4e", size = 11171963 },
-    { url = "https://files.pythonhosted.org/packages/43/18/bb0befb7fb9121dd9009e6a72eb98e24f1bacb07c6f3ecb55f032ba98aed/ruff-0.7.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6b6224af8b5e09772c2ecb8dc9f3f344c1aa48201c7f07e7315367f6dd90ac29", size = 11856157 },
-    { url = "https://files.pythonhosted.org/packages/5e/91/04e98d7d6e32eca9d1372be595f9abc7b7f048795e32eb2edbd8794d50bd/ruff-0.7.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c50f95a82b94421c964fae4c27c0242890a20fe67d203d127e84fbb8013855f5", size = 11440331 },
-    { url = "https://files.pythonhosted.org/packages/f5/dc/3fe99f2ce10b76d389041a1b9f99e7066332e479435d4bebcceea16caff5/ruff-0.7.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f3eff9961b5d2644bcf1616c606e93baa2d6b349e8aa8b035f654df252c8c67", size = 12725354 },
-    { url = "https://files.pythonhosted.org/packages/43/7b/1daa712de1c5bc6cbbf9fa60e9c41cc48cda962dc6d2c4f2a224d2c3007e/ruff-0.7.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8963cab06d130c4df2fd52c84e9f10d297826d2e8169ae0c798b6221be1d1d2", size = 11010091 },
-    { url = "https://files.pythonhosted.org/packages/b6/db/1227a903587432eb569e57a95b15a4f191a71fe315cde4c0312df7bc85da/ruff-0.7.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:61b46049d6edc0e4317fb14b33bd693245281a3007288b68a3f5b74a22a0746d", size = 10610687 },
-    { url = "https://files.pythonhosted.org/packages/db/e2/dc41ee90c3085aadad4da614d310d834f641aaafddf3dfbba08210c616ce/ruff-0.7.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10ebce7696afe4644e8c1a23b3cf8c0f2193a310c18387c06e583ae9ef284de2", size = 10254843 },
-    { url = "https://files.pythonhosted.org/packages/6f/09/5f6cac1c91542bc5bd33d40b4c13b637bf64d7bb29e091dadb01b62527fe/ruff-0.7.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3f36d56326b3aef8eeee150b700e519880d1aab92f471eefdef656fd57492aa2", size = 10730962 },
-    { url = "https://files.pythonhosted.org/packages/d3/42/89a4b9a24ef7d00269e24086c417a006f9a3ffeac2c80f2629eb5ce140ee/ruff-0.7.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5d024301109a0007b78d57ab0ba190087b43dce852e552734ebf0b0b85e4fb16", size = 11101907 },
-    { url = "https://files.pythonhosted.org/packages/b0/5c/efdb4777686683a8edce94ffd812783bddcd3d2454d38c5ac193fef7c500/ruff-0.7.3-py3-none-win32.whl", hash = "sha256:4ba81a5f0c5478aa61674c5a2194de8b02652f17addf8dfc40c8937e6e7d79fc", size = 8611095 },
-    { url = "https://files.pythonhosted.org/packages/bb/b8/28fbc6a4efa50178f973972d1c84b2d0a33cdc731588522ab751ac3da2f5/ruff-0.7.3-py3-none-win_amd64.whl", hash = "sha256:588a9ff2fecf01025ed065fe28809cd5a53b43505f48b69a1ac7707b1b7e4088", size = 9418283 },
-    { url = "https://files.pythonhosted.org/packages/3f/77/b587cba6febd5e2003374f37eb89633f79f161e71084f94057c8653b7fb3/ruff-0.7.3-py3-none-win_arm64.whl", hash = "sha256:1713e2c5545863cdbfe2cbce21f69ffaf37b813bfd1fb3b90dc9a6f1963f5a8c", size = 8725228 },
-]
+version = "0.9.5"
+source = { git = "https://github.com/thejcannon/ruff.git?rev=exit-non-zero-on-format#05ff08beeb9b5737ab5c9414ef873c94e731fe17" }
 
 [[package]]
 name = "shimbboleth"
-version = "0.0.2.dev2+gcf43bee.d20250205"
+version = "0.0.2.dev3+g527bf83.d20250207"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -400,7 +380,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-trio", specifier = ">=0.8.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "ruff", specifier = ">=0.7.3" },
+    { name = "ruff", git = "https://github.com/thejcannon/ruff.git?rev=exit-non-zero-on-format" },
     { name = "trio", specifier = ">=0.27.0" },
 ]
 


### PR DESCRIPTION
Turns out:
- lefthook doesn't do the same file-checking pre-commit does (I kinda like this though)
- ruff wasn't erroring on format/fix

For `--fix`, there's a flag. For `format` I had to add one (hence the fork pin, for now)